### PR TITLE
Fix split restart crash and remove duplicate split button

### DIFF
--- a/app/src/main/res/layout/activity_screen_recording.xml
+++ b/app/src/main/res/layout/activity_screen_recording.xml
@@ -50,13 +50,6 @@
         android:text="Split &amp; Save Current Clip"
         android:layout_marginBottom="32dp" />
 
-    <Button
-        android:id="@+id/splitButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Split &amp; Save Current Clip"
-        android:layout_marginBottom="32dp" />
-
     <TextView
         android:id="@+id/fileInfoTextView"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- giữ lại MediaProjection khi tách bản ghi để tránh tạo lại virtual display từ token đã hết hạn
- cho phép stopRecordingInternal kiểm soát việc dừng MediaProjection và dùng tuỳ chọn mới khi split
- xoá nút Split trùng lặp trong màn hình ScreenRecording để chỉ còn một nút
- hủy đăng ký tạm thời callback MediaProjection khi split để tránh callback onStop làm vô hiệu hoá token trước khi khởi động lại

## Testing
- ./gradlew lint *(fails: thiếu Android SDK trong môi trường CI)*

------
https://chatgpt.com/codex/tasks/task_e_68cef4bbf48c8333807cef51f60be3ff